### PR TITLE
Improve aimbot target and add fixed setup_bones

### DIFF
--- a/src/NullHooks.vcxproj
+++ b/src/NullHooks.vcxproj
@@ -258,6 +258,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="core\config\config.hpp" />
+    <ClInclude Include="core\features\aim\autowall.hpp" />
     <ClInclude Include="core\features\features.hpp" />
     <ClInclude Include="core\features\misc\backtrack.hpp" />
     <ClInclude Include="core\features\visuals\skin_changer\skin_changer.hpp" />

--- a/src/core/config/load.cpp
+++ b/src/core/config/load.cpp
@@ -48,6 +48,7 @@ bool config::load_config(std::string filename) {
 	load::parse_bool(doc,			variables::aim::autofire,								"aim",				"autofire");
 	load::parse_hotkey(doc,			variables::aim::aimbot_key,								"aim",				"aimbot_key");
 	load::parse_bool(doc,			variables::aim::bodyaim_if_lethal,						"aim",				"bodyaim_if_lethal");
+	load::parse_bool(doc,			variables::aim::priorize_lethal_targets,				"aim",				"priorize_lethal_targets");
 	load::parse_combobox(doc,		variables::aim::autowall,								"aim",				"autowall");
 	load::parse_float(doc,			variables::aim::aimbot_fov,								"aim",				"aimbot_fov");
 	load::parse_bool(doc,			variables::aim::draw_fov,								"aim",				"draw_fov");

--- a/src/core/config/save.cpp
+++ b/src/core/config/save.cpp
@@ -43,6 +43,7 @@ bool config::save_config(std::string filename) {
 		save::parse_bool(aim,					allocator,			variables::aim::autofire,								"autofire");
 		save::parse_hotkey(aim,					allocator,			variables::aim::aimbot_key,								"aimbot_key");
 		save::parse_bool(aim,					allocator,			variables::aim::bodyaim_if_lethal,						"bodyaim_if_lethal");
+		save::parse_bool(aim,					allocator,			variables::aim::priorize_lethal_targets,				"priorize_lethal_targets");
 		save::parse_combobox(aim,				allocator,			variables::aim::autowall,								"autowall");
 		save::parse_float(aim,					allocator,			variables::aim::aimbot_fov,								"aimbot_fov");
 		save::parse_bool(aim,					allocator,			variables::aim::draw_fov,								"draw_fov");

--- a/src/core/features/aim/aimbot.cpp
+++ b/src/core/features/aim/aimbot.cpp
@@ -104,7 +104,7 @@ vec3_t get_best_target(c_usercmd* cmd, weapon_t* active_weapon) {
 		if (!helpers::is_enemy(entity) && !variables::aim::target_friends) continue;
 
 		for (const auto hitbox : all_hitboxes) {
-			auto hitbox_pos = entity->get_hitbox_position(hitbox);
+			auto hitbox_pos = entity->get_hitbox_position_fixed(hitbox);
 			bool enabled_hitbox = std::find(selected_hitboxes.begin(), selected_hitboxes.end(), hitbox) != selected_hitboxes.end();
 
 			// Ignore everything if we have "ignore walls" setting (2)
@@ -127,8 +127,6 @@ vec3_t get_best_target(c_usercmd* cmd, weapon_t* active_weapon) {
 		}
 	}
 
-	// For debugging
-	interfaces::debug_overlay->add_line_overlay(local_eye_pos, best_target, color::green(200), false, 1.f);
 	return best_target;		// vec3_t position of the best bone
 }
 #pragma endregion

--- a/src/core/features/aim/aimbot.cpp
+++ b/src/core/features/aim/aimbot.cpp
@@ -91,6 +91,8 @@ vec3_t get_best_target(c_usercmd* cmd, weapon_t* active_weapon) {
 	const auto weapon_data = active_weapon->get_weapon_data();
 	if (!weapon_data) return best_target;
 
+	auto local_eye_pos = csgo::local_player->get_eye_pos();		// Get eye pos from origin player_t
+
 	// Check each player
 	for (int i = 1; i <= interfaces::globals->max_clients; i++) {
 		auto entity = reinterpret_cast<player_t*>(interfaces::entity_list->get_client_entity(i));
@@ -100,8 +102,6 @@ vec3_t get_best_target(c_usercmd* cmd, weapon_t* active_weapon) {
 			|| entity->dormant()
 			|| entity->has_gun_game_immunity()) continue;
 		if (!helpers::is_enemy(entity) && !variables::aim::target_friends) continue;
-
-		auto local_eye_pos = csgo::local_player->get_eye_pos();		// Get eye pos from origin player_t
 
 		for (const auto hitbox : all_hitboxes) {
 			auto hitbox_pos = entity->get_hitbox_position(hitbox);
@@ -127,6 +127,8 @@ vec3_t get_best_target(c_usercmd* cmd, weapon_t* active_weapon) {
 		}
 	}
 
+	// For debugging
+	interfaces::debug_overlay->add_line_overlay(local_eye_pos, best_target, color::green(200), false, 1.f);
 	return best_target;		// vec3_t position of the best bone
 }
 #pragma endregion

--- a/src/core/features/aim/autowall.cpp
+++ b/src/core/features/aim/autowall.cpp
@@ -94,8 +94,8 @@ static bool aim::autowall::handle_bullet_penetration(surface_data* enter_surface
 #pragma region AUTOWALL
 // Used to check if target it visible or hittable. Used in aimbot.
 // enabled_hitbox will be used to know what hitboxes are enabled by the user (cuz now its iterating all due to bodyaim_if_lethal)
-bool aim::autowall::handle_walls(player_t* local_player, entity_t* entity, const vec3_t& destination, const weapon_info_t* weapon_data, int min_damage, bool enabled_hitbox) {
-	if (!variables::aim::bodyaim_if_lethal && !enabled_hitbox) return false;
+autowall_data_t aim::autowall::handle_walls(player_t* local_player, entity_t* entity, const vec3_t& destination, const weapon_info_t* weapon_data, bool enabled_hitbox) {
+	if (!variables::aim::bodyaim_if_lethal && !enabled_hitbox) return { false, 0.f };
 
 	float damage = static_cast<float>(weapon_data->weapon_damage);
 	vec3_t start = local_player->get_eye_pos();
@@ -124,23 +124,24 @@ bool aim::autowall::handle_walls(player_t* local_player, entity_t* entity, const
 			
 			// If we can kill and we have the setting enabled, ignore enabled hitboxes and shoot
 			if (variables::aim::bodyaim_if_lethal && reinterpret_cast<player_t*>(entity)->health() < damage)
-				return true;		
+				return {true, damage};
 			// If we can't kill, the best place to shoot is the closest enabled hitbox
 			else if (enabled_hitbox)
-				return damage >= min_damage;
+				return { false, damage };
 		}
-		if (variables::aim::autowall.idx == 0) return false;
+		// Return false (invalid) if we care only about visible and we dont see the target
+		if (variables::aim::autowall.idx == 0) return { false, 0.f };
 
 		const auto surface_data = interfaces::surface_props_physics->get_surface_data(trace.surface.surfaceProps);
 		if (surface_data->penetrationmodifier < 0.1f) break;
 
 		// Start and damage are changed from handle_bullet_penetration()
 		if (!autowall::handle_bullet_penetration(surface_data, trace, direction, start, weapon_data->weapon_penetration, damage))
-			return false;
+			return { false, 0.f };
 
 		hits_left--;
 	}
 
-	return false;
+	return { false, 0.f };
 }
 #pragma endregion

--- a/src/core/features/aim/autowall.cpp
+++ b/src/core/features/aim/autowall.cpp
@@ -95,7 +95,7 @@ static bool aim::autowall::handle_bullet_penetration(surface_data* enter_surface
 // Used to check if target it visible or hittable. Used in aimbot.
 // enabled_hitbox will be used to know what hitboxes are enabled by the user (cuz now its iterating all due to bodyaim_if_lethal)
 autowall_data_t aim::autowall::handle_walls(player_t* local_player, entity_t* entity, const vec3_t& destination, const weapon_info_t* weapon_data, bool enabled_hitbox) {
-	if (!variables::aim::bodyaim_if_lethal && !enabled_hitbox) return { false, 0.f };
+	if (!variables::aim::bodyaim_if_lethal && !enabled_hitbox) return { false, -1.f };
 
 	float damage = static_cast<float>(weapon_data->weapon_damage);
 	vec3_t start = local_player->get_eye_pos();
@@ -124,24 +124,24 @@ autowall_data_t aim::autowall::handle_walls(player_t* local_player, entity_t* en
 			
 			// If we can kill and we have the setting enabled, ignore enabled hitboxes and shoot
 			if (variables::aim::bodyaim_if_lethal && reinterpret_cast<player_t*>(entity)->health() < damage)
-				return {true, damage};
+				return { true, damage };
 			// If we can't kill, the best place to shoot is the closest enabled hitbox
 			else if (enabled_hitbox)
 				return { false, damage };
 		}
-		// Return false (invalid) if we care only about visible and we dont see the target
-		if (variables::aim::autowall.idx == 0) return { false, 0.f };
+		// Return invalid if we care only about visible and we dont see the target. This should never happen.
+		//if (variables::aim::autowall.idx == 0) return { false, -1.f };
 
 		const auto surface_data = interfaces::surface_props_physics->get_surface_data(trace.surface.surfaceProps);
 		if (surface_data->penetrationmodifier < 0.1f) break;
 
 		// Start and damage are changed from handle_bullet_penetration()
 		if (!autowall::handle_bullet_penetration(surface_data, trace, direction, start, weapon_data->weapon_penetration, damage))
-			return { false, 0.f };
+			return { false, -1.f };
 
 		hits_left--;
 	}
 
-	return { false, 0.f };
+	return { false, -1.f };
 }
 #pragma endregion

--- a/src/core/features/aim/autowall.hpp
+++ b/src/core/features/aim/autowall.hpp
@@ -2,5 +2,5 @@
 
 struct autowall_data_t {
 	bool lethal;
-	float damage;
+	float damage;		// Negative damage means invalid
 };

--- a/src/core/features/aim/autowall.hpp
+++ b/src/core/features/aim/autowall.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+struct autowall_data_t {
+	bool lethal;
+	float damage;
+};

--- a/src/core/features/features.hpp
+++ b/src/core/features/features.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "source-sdk/sdk.hpp"
 #include "core/features/misc/backtrack.hpp"
+#include "core/features/aim/autowall.hpp"
 
 namespace antiaim {
 	void run_antiaim(c_usercmd* cmd, bool& sendPacket);
@@ -26,7 +27,7 @@ namespace aim {
 		bool is_armored(int hit_group, bool helmet);
 		bool trace_to_exit(trace_t& enter_trace, vec3_t& start, const vec3_t& direction, vec3_t& end, trace_t& exit_trace);
 		static bool handle_bullet_penetration(surface_data* enter_surface_data, trace_t& enter_trace, const vec3_t& direction, vec3_t& start, float penetration, float& damage);
-		bool handle_walls(player_t* local_player, entity_t* entity, const vec3_t& destination, const weapon_info_t* weapon_data, int min_damage, bool enabled_hitbox);
+		autowall_data_t handle_walls(player_t* local_player, entity_t* entity, const vec3_t& destination, const weapon_info_t* weapon_data, bool enabled_hitbox);
 	}
 }
 

--- a/src/core/features/misc/engine_prediction.cpp
+++ b/src/core/features/misc/engine_prediction.cpp
@@ -12,7 +12,7 @@ float prediction::get_server_time(c_usercmd* cmd) {
 			tick = *(UINT*)((uintptr_t)local + (netvar_manager::get_net_var(fnv::hash("DT_CSPlayer"), fnv::hash("m_nTickBase"))));
 		else
 			tick++;
-		
+
 		last_cmd = cmd;
 	}
 
@@ -28,7 +28,7 @@ void prediction::start(c_usercmd* cmd) {
 	custom_inpred = true;
 
 	*csgo::local_player->current_command() = cmd;
-	csgo::local_player->last_command( ) = *cmd;
+	csgo::local_player->last_command() = *cmd;
 
 	// last_command
 	*reinterpret_cast<c_usercmd**>(uintptr_t(csgo::local_player) + 0x3298) = cmd;
@@ -114,8 +114,7 @@ void prediction::post_think() {
 }
 
 void prediction::end() {
-	if (!csgo::local_player)
-		return;
+	if (!csgo::local_player) return;
 
 	custom_inpred = false;
 

--- a/src/core/features/visuals/player_esp.cpp
+++ b/src/core/features/visuals/player_esp.cpp
@@ -86,8 +86,8 @@ void visuals::playeresp() {
 		if (!player_model) continue;
 		auto hdr = interfaces::model_info->get_studio_model(player_model);
 		if (!hdr) continue;
-		static matrix_t bones[128];
-		if (!player->setup_bones(bones, 128, 256, 0)) continue;
+		static matrix_t bones[MAXSTUDIOBONES];
+		if (!player->setup_bones(bones, MAXSTUDIOBONES, BONE_USED_BY_HITBOX, 0)) continue;
 
 		int x, y, w, h;
 		if (!bbox(player, x, y, w, h)) continue;

--- a/src/core/helpers/helpers.cpp
+++ b/src/core/helpers/helpers.cpp
@@ -2,7 +2,7 @@
 #include "core/helpers/helpers.hpp"
 
 #pragma region CONSOLE
-void helpers::console::state_to_console(const char* tag,  const char* text) {
+void helpers::console::state_to_console(const char* tag, const char* text) {
 	interfaces::console->printf("[NullHooks] [%s] %s\n", tag, text);
 }
 
@@ -158,7 +158,7 @@ void helpers::chat::save_config(std::string config_name) {
 
 #pragma region MISC
 template <typename T>
-static constexpr auto relativeToAbsolute(uint8_t* address) noexcept {
+static constexpr auto helpers::relative_to_absolute(uint8_t* address) {
 	return (T)(address + 4 + *reinterpret_cast<std::int32_t*>(address));
 }
 
@@ -173,7 +173,7 @@ bool helpers::is_enemy(player_t* player) {
 	if (!csgo::local_player || !player) return false;
 
 	using fn = bool(__thiscall*)(player_t*, player_t*);
-	static fn isOtherEnemy = relativeToAbsolute<fn>(utilities::pattern_scan("client.dll", "8B CE E8 ? ? ? ? 02 C0") + 3);
+	static fn isOtherEnemy = relative_to_absolute<fn>(utilities::pattern_scan("client.dll", "8B CE E8 ? ? ? ? 02 C0") + 3);
 
 	isOtherEnemy(csgo::local_player, player);
 }

--- a/src/core/helpers/helpers.hpp
+++ b/src/core/helpers/helpers.hpp
@@ -7,7 +7,7 @@ struct int_hsv {
 	float s;	// Max: 1.f
 	float v;	// Max: 1.f
 
-	int_hsv( ) = default;
+	int_hsv() = default;
 	int_hsv(int_hsv& hsv) {
 		this->h = hsv.h;
 		this->s = hsv.s;
@@ -25,7 +25,7 @@ struct int_hsv {
 struct float_hsv {
 	float h, s, v;	// Max: 1.f
 
-	float_hsv( ) = default;
+	float_hsv() = default;
 	float_hsv(float_hsv& hsv) {
 		this->h = hsv.h;
 		this->s = hsv.s;
@@ -47,7 +47,7 @@ struct float_hsv {
 struct float_color {
 	float r, g, b;	// Max: 1.f
 
-	float_color( ) = default;
+	float_color() = default;
 	float_color(float_color& hsv) {
 		this->r = hsv.r;
 		this->g = hsv.g;
@@ -100,13 +100,16 @@ namespace helpers {
 		float_hsv color2hsv_float(color col);
 		color float2color(float* id);
 	}
-	
+
 	namespace chat {
 		void print(std::string str);
 		void print(std::string str, char col);		// Prints 'NullHooks | str' with color
 		void load_config(std::string config_name);
 		void save_config(std::string config_name);
 	}
+
+	template <typename T>
+	static constexpr auto relative_to_absolute(uint8_t* address);
 
 	player_t* local_or_spectated();
 	bool is_enemy(player_t* player);

--- a/src/core/hooks/functions/create_move.cpp
+++ b/src/core/hooks/functions/create_move.cpp
@@ -54,16 +54,15 @@ bool hooks::create_move::hook(float input_sample_frametime, c_usercmd *cmd, bool
 		misc::movement::edgebug(cmd, old_flags);
 		misc::movement::post_pred_jumpbug(cmd, old_flags);
 
-		backtrack::run(cmd);
+		aim::triggerbot(cmd);
+		aim::run_aimbot(cmd);
 
+		antiaim::run_antiaim(cmd, send_packet);
+
+		backtrack::run(cmd);
 	} prediction::end();
 
 	misc::movement::edgejump(cmd, old_flags);
-
-	aim::triggerbot(cmd);
-	aim::run_aimbot(cmd);
-
-	antiaim::run_antiaim(cmd, send_packet);
 
 	/* ------------------------------------------------------------------------ */
 

--- a/src/core/hooks/functions/create_move.cpp
+++ b/src/core/hooks/functions/create_move.cpp
@@ -53,15 +53,17 @@ bool hooks::create_move::hook(float input_sample_frametime, c_usercmd *cmd, bool
 	prediction::start(cmd); {
 		misc::movement::edgebug(cmd, old_flags);
 		misc::movement::post_pred_jumpbug(cmd, old_flags);
-		aim::triggerbot(cmd);
-		aim::run_aimbot(cmd);
 
 		backtrack::run(cmd);
-		
-		antiaim::run_antiaim(cmd, send_packet);
+
 	} prediction::end();
 
 	misc::movement::edgejump(cmd, old_flags);
+
+	aim::triggerbot(cmd);
+	aim::run_aimbot(cmd);
+
+	antiaim::run_antiaim(cmd, send_packet);
 
 	/* ------------------------------------------------------------------------ */
 

--- a/src/core/menu/menu.cpp
+++ b/src/core/menu/menu.cpp
@@ -56,18 +56,19 @@ void menu::render() {
 				gui::add_slider		("Triggerbot delay",	variables::aim::triggerbot_delay, 0.f, 30.f);
 			}
 
-			gui::add_groupbox("Aimbot", 11); {
-				gui::add_checkbox		("Enable aimbot",		variables::aim::aimbot);
-				gui::add_checkbox		("Autofire",			variables::aim::autofire);
-				gui::add_hotkey			("Only on key",			variables::aim::aimbot_key);
-				gui::add_checkbox		("Silent",				variables::aim::silent);
-				gui::add_combobox		("Autowall",			variables::aim::autowall_settings, variables::aim::autowall);
-				gui::add_multicombobox	("Aimbot hitboxes",		variables::aim::hitboxes);
-				gui::add_checkbox		("Bodyaim if lethal",	variables::aim::bodyaim_if_lethal);
-				gui::add_slider			("Minimum damage",		variables::aim::min_damage, 0.f, 100.f);
-				gui::add_slider			("Aimbot fov",			variables::aim::aimbot_fov, 0.f, 180.f);
-				gui::add_checkbox		("Draw fov",			variables::aim::draw_fov, variables::colors::aimbot_fov_c);
-				gui::add_slider			("Aimbot smoothing",	variables::aim::aimbot_smoothing, 0.f, 1.f);
+			gui::add_groupbox("Aimbot", 12); {
+				gui::add_checkbox		("Enable aimbot",			variables::aim::aimbot);
+				gui::add_checkbox		("Autofire",				variables::aim::autofire);
+				gui::add_hotkey			("Only on key",				variables::aim::aimbot_key);
+				gui::add_checkbox		("Silent",					variables::aim::silent);
+				gui::add_combobox		("Autowall",				variables::aim::autowall_settings, variables::aim::autowall);
+				gui::add_multicombobox	("Aimbot hitboxes",			variables::aim::hitboxes);
+				gui::add_checkbox		("Bodyaim if lethal",		variables::aim::bodyaim_if_lethal);
+				gui::add_checkbox		("Priorize lethal targets",	variables::aim::priorize_lethal_targets);
+				gui::add_slider			("Minimum damage",			variables::aim::min_damage, 0.f, 100.f);
+				gui::add_slider			("Aimbot fov",				variables::aim::aimbot_fov, 0.f, 180.f);
+				gui::add_checkbox		("Draw fov",				variables::aim::draw_fov, variables::colors::aimbot_fov_c);
+				gui::add_slider			("Aimbot smoothing",		variables::aim::aimbot_smoothing, 0.f, 1.f);
 			}
 
 			/* -------- Aim - Second column -------- */

--- a/src/core/menu/variables.hpp
+++ b/src/core/menu/variables.hpp
@@ -12,7 +12,9 @@ namespace variables {
 		inline bool silent = false;
 		inline bool autofire = false;
 		inline hotkey_t aimbot_key(VK_NEXT);
+
 		inline bool bodyaim_if_lethal = false;
+		inline bool priorize_lethal_targets = false;		// If we can kill a someone inside our fov, go for it even if it's not the closest one
 
 		inline std::vector<std::string> autowall_settings = {
 			"Only visible",

--- a/src/source-sdk/classes/collideable.hpp
+++ b/src/source-sdk/classes/collideable.hpp
@@ -2,12 +2,12 @@
 
 class collideable_t {
 public:
-	vec3_t& mins() {
-		using original_fn = vec3_t & (__thiscall*)(void*);
-		return (*(original_fn * *)this)[1](this);
+	vec3_t obb_mins() {
+		using original_fn = vec3_t*(__thiscall*)(void*);
+		return *((*(original_fn**)this)[1](this));
 	}
-	vec3_t& maxs() {
-		using original_fn = vec3_t & (__thiscall*)(void*);
-		return (*(original_fn * *)this)[2](this);
+	vec3_t obb_maxs() {
+		using original_fn = vec3_t*(__thiscall*)(void*);
+		return *((*(original_fn**)this)[2](this));
 	}
 };

--- a/src/source-sdk/classes/entities.hpp
+++ b/src/source-sdk/classes/entities.hpp
@@ -5,6 +5,7 @@
 #include "source-sdk/structs/animstate.hpp"
 #include "dependencies/utilities/utilities.hpp"
 #include "dependencies/utilities/netvars/netvars.hpp"
+#include "source-sdk/classes/collideable.hpp"
 
 #pragma region ENUMS
 enum data_update_type_t {
@@ -312,17 +313,6 @@ const std::unordered_map<std::string, int> all_custom_models = {
 	{ "ARMS",							ARMS }
 };
 
-struct collideable_t {
-	vec3_t obb_mins() {
-		using original_fn = vec3_t * (__thiscall*)(void*);
-		return *((*(original_fn**)this)[1](this));
-	};
-	vec3_t obb_maxs() {
-		using original_fn = vec3_t * (__thiscall*)(void*);
-		return *((*(original_fn**)this)[2](this));
-	};
-};
-
 template <typename T>
 static constexpr auto relative_to_absolute(uint8_t* address) {
 	return (T)(address + 4 + *reinterpret_cast<std::int32_t*>(address));
@@ -397,7 +387,7 @@ public:
 		// Fix bone matrix. First store abs_origina nad effects
 		vec3_t actual_abs_origin = abs_origin();
 		uintptr_t backup_effects = get_effects();
-		
+
 		this->invalidate_bone_cache();
 		get_effects() |= 8;
 
@@ -406,7 +396,7 @@ public:
 		set_abs_origin(this, origin());
 
 		auto result = (*(original_fn**)animating())[13](animating(), out, max_bones, mask, time);		// Get original result from vfunc with origin
-		
+
 		// Restore old origin and effects
 		set_abs_origin(this, actual_abs_origin);
 		get_effects() = backup_effects;
@@ -462,19 +452,19 @@ public:
 	}
 
 	vec3_t& abs_origin() {
-		using original_fn = vec3_t&(__thiscall*)(void*);
+		using original_fn = vec3_t & (__thiscall*)(void*);
 		return (*(original_fn**)this)[10](this);;
 	}
 
 	NETVAR("DT_BaseEntity", "m_hOwnerEntity", owner_handle, unsigned long);
 	NETVAR("DT_BaseEntity", "m_bSpotted", spotted, bool);
-	
+
 	NETVAR("DT_CSPlayer", "m_fFlags", flags, int);
 	NETVAR("DT_CSPlayer", "m_flSimulationTime", simulation_time, float);
 	NETVAR("DT_CSPlayer", "m_iTeamNum", team, int);
 	NETVAR("DT_CSPlayer", "m_nSurvivalTeam", survival_team, int);
 	NETVAR("DT_CSPlayer", "m_flHealthShotBoostExpirationTime", health_boost_time, float);
-	
+
 	NETVAR("DT_BasePlayer", "m_vecOrigin", origin, vec3_t);
 	NETVAR("DT_BasePlayer", "m_vecViewOffset[0]", view_offset, vec3_t);
 


### PR DESCRIPTION
#### Changes:
- Changes to aimbot's `get_best_target()`
    - Prioritize player's hitboxes with more damage instead of closest to fov.
    - Stop iterating players/hitboxes once we find a valid target (Not on fov, found lethal hitbox, etc). Improves performance.
    - Add `priorize_lethal_targets` option prioritizing the closest enemy that we can kill instead of the closest hitable one.
- Add `get_hitbox_position_fixed()` and `setup_bones_fixed()` functions for getting bones based on `entity->origin()` instead of `entity->abs_origin()`.
- Remove duplicate `collideable_t` class (#70)
